### PR TITLE
Fix make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ compile: $(REBAR)
 	$(REBAR) as dev compile
 
 run: $(REBAR)
-	@$(REBAR) as dev shell --apps pooler --config config/demo.config
+	@$(REBAR) as test shell --apps pooler --config config/demo.config
 
 test: $(REBAR)
 	$(REBAR) eunit --verbose --cover

--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,8 @@
     }
 ]}.
 
-{eunit_opts, [{report, {eunit_progress, [colored, profile]}}]}.
+{eunit_opts, [{report, {eunit_progress, [colored, profile]}},
+              {print_depth, 100}]}.
 {eunit_compile_opts, [export_all]}.
 
 {ct_opts, []}.


### PR DESCRIPTION
Since `pooler_gs` module, which is used for `make run` is only available in `test` profile, run `make run` in this `test` profile instead of `dev`.

Also, PR includes a tiny unrelated commit to increase eunit print depth