### PR TITLE
Limit the access to the `#pool` record

### DIFF
--- a/src/pooler_config.erl
+++ b/src/pooler_config.erl
@@ -4,7 +4,7 @@
 
 -module(pooler_config).
 
--export([list_to_pool/1]).
+-export([list_to_pool/1, get_name/1, get_start_mfa/1, group_table/0]).
 
 -include("pooler.hrl").
 
@@ -26,6 +26,18 @@ list_to_pool(P) ->
         metrics_api = ?gv(metrics_api, P, folsom),
         queue_max = ?gv(queue_max, P, ?DEFAULT_POOLER_QUEUE_MAX)
     }.
+
+-spec get_name(#pool{}) -> pooler:pool_name().
+get_name(#pool{name = Name}) ->
+    Name.
+
+-spec get_start_mfa(pooler:pool_state()) -> {module(), atom(), [any()]}.
+get_start_mfa(#pool{start_mfa = MFA}) ->
+    MFA.
+
+-spec group_table() -> atom().
+group_table() ->
+    ?POOLER_GROUP_TABLE.
 
 %% Return `Value' for `Key' in proplist `P' or crashes with an
 %% informative message if no value is found.

--- a/src/pooler_pool_sup.erl
+++ b/src/pooler_pool_sup.erl
@@ -10,13 +10,12 @@
     build_member_sup_name/1
 ]).
 
--include("pooler.hrl").
-
-start_link(#pool{} = Pool) ->
+-spec start_link(pooler:pool_state()) -> {ok, pid()}.
+start_link(Pool) ->
     SupName = pool_sup_name(Pool),
     supervisor:start_link({local, SupName}, ?MODULE, Pool).
 
-init(#pool{} = Pool) ->
+init(Pool) ->
     PoolerSpec = {pooler, {pooler, start_link, [Pool]}, transient, 5000, worker, [pooler]},
     MemberSupName = member_sup_name(Pool),
     MemberSupSpec =
@@ -28,11 +27,11 @@ init(#pool{} = Pool) ->
     Restart = {one_for_all, 5, 60},
     {ok, {Restart, [MemberSupSpec, PoolerSpec]}}.
 
-member_sup_name(#pool{name = PoolName}) ->
-    build_member_sup_name(PoolName).
+member_sup_name(Pool) ->
+    build_member_sup_name(pooler_config:get_name(Pool)).
 
 build_member_sup_name(PoolName) ->
     list_to_atom("pooler_" ++ atom_to_list(PoolName) ++ "_member_sup").
 
-pool_sup_name(#pool{name = PoolName}) ->
-    list_to_atom("pooler_" ++ atom_to_list(PoolName) ++ "_pool_sup").
+pool_sup_name(Pool) ->
+    list_to_atom("pooler_" ++ atom_to_list(pooler_config:get_name(Pool)) ++ "_pool_sup").

--- a/src/pooler_pooled_worker_sup.erl
+++ b/src/pooler_pooled_worker_sup.erl
@@ -4,9 +4,8 @@
 
 -export([start_link/1, init/1]).
 
--include("pooler.hrl").
-
-start_link(#pool{start_mfa = {_, _, _} = MFA} = Pool) ->
+start_link(Pool) ->
+    MFA = pooler_config:get_start_mfa(Pool),
     SupName = pooler_pool_sup:member_sup_name(Pool),
     supervisor:start_link({local, SupName}, ?MODULE, MFA).
 

--- a/src/pooler_starter.erl
+++ b/src/pooler_starter.erl
@@ -5,7 +5,6 @@
 -module(pooler_starter).
 -behaviour(gen_server).
 
--include("pooler.hrl").
 -include_lib("kernel/include/logger.hrl").
 
 %% ------------------------------------------------------------------

--- a/test/prop_pooler.erl
+++ b/test/prop_pooler.erl
@@ -12,7 +12,6 @@
 
 -include_lib("proper/include/proper.hrl").
 -include_lib("stdlib/include/assert.hrl").
--include("pooler.hrl").
 
 prop_fixed_start(doc) ->
     "Check that the pool of any fixed size can be started, internal statistics is correct".


### PR DESCRIPTION
this is to make it safer to upgrade the record