### PR TITLE
Add `code_change` implementation and `appup` and hot upgrade test

### DIFF
--- a/.github/workflows/hot_upgrade.yml
+++ b/.github/workflows/hot_upgrade.yml
@@ -1,0 +1,35 @@
+name: Hot upgrade
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ci:
+    name: Hot code upgrade from ${{ matrix.from_version }} on OTP-${{ matrix.otp }}
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["ubuntu-20.04"]
+        otp: ["23.3"]
+        rebar3: ["3.17.0"]
+        from_version:
+            - "1.5.2"
+            - "9c28fb479f9329e2a1644565a632bc222780f1b7"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          rebar3-version: ${{ matrix.rebar3 }}
+
+      - name: Hot-upgrade
+        run: make hotupgrade_setup BASE_REV=${{ matrix.from_version }} hotupgrade_check

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ clean: $(REBAR)
 dialyzer: $(REBAR)
 	$(REBAR) dialyzer
 
+hotupgrade_setup: $(REBAR)
+	./test/hotupgrade_test.sh setup $(BASE_REV)
+
+hotupgrade_check:
+	./test/hotupgrade_test.sh check
+
 # Get rebar3 if it doesn't exist. If rebar3 was found on PATH, the
 # $(REBAR) dep will be satisfied since the file will exist.
 

--- a/README.org
+++ b/README.org
@@ -347,6 +347,20 @@ Please attach the output of ~rebar3 bench --baseline master~ after your changes 
 in order to prove that there were no performance regressions. Please attach the OTP version you run the
 benchmarks on.
 
+*** New release
+
+Our goal is to allow the hot code upgrade of ~pooler~, so it is shipped with ~.appup~ file and hot upgrade
+procedure is tested in CI.
+
+To cut a new release, do the following steps:
+
+1. In ~src/pooler.app.src~: update the ~vsn~
+2. In ~src/pooler.appup.src~: replace the contents with upgrade instructions for a new release
+3. In ~test/relx-base.config~: update the ~pooler~'s app version to a previous release (or leave it without version)
+4. In ~test/relx-current.config~: update the ~pooler~'s app version to a new one
+5. In ~.github/workflows/hot_upgrade.yml~: update ~from_version~ to a previous release, maybe bump OTP version as well
+6. Push, wait for the green build, tag
+
 ** License
 Pooler is licensed under the Apache License Version 2.0.  See the
 [[file:LICENSE][LICENSE]] file for details.

--- a/src/pooler.app.src
+++ b/src/pooler.app.src
@@ -1,11 +1,13 @@
 {application, pooler, [
     {description, "An OTP Process Pool Application"},
-    {vsn, git},
-    {registered, []},
+    {vsn, "1.6.0"},
+    {registered, [pooler_sup, pooler_starter_sup]},
     {applications, [
         kernel,
         stdlib
     ]},
     {mod, {pooler_app, []}},
-    {env, []}
+    {env, []},
+    {licenses, ["Apache License 2.0"]},
+    {links, [{"Github", "https://github.com/epgsql/pooler"}]}
 ]}.

--- a/src/pooler.appup.src
+++ b/src/pooler.appup.src
@@ -1,0 +1,24 @@
+% -*- mode: erlang -*-
+{"1.6.0",
+  [{<<"1\\.5\\.2.*">>,
+    [{update, pooler, {advanced, []}},
+     {load_module, pooler_starter},
+     {load_module, pooler_app},
+     {update, pooler_sup, supervisor},
+     {update, pooler_pool_sup, supervisor},
+     {update, pooler_starter_sup, supervisor},
+     {update, pooler_pooled_worker_sup, supervisor},
+     {delete_module, pooler_config}]
+   },
+   {<<"1\\.5\\.3.*">>,
+    [{update, pooler, {advanced, []}},
+     {load_module, pooler_starter},
+     {load_module, pooler_app},
+     {update, pooler_sup, supervisor},
+     {update, pooler_pool_sup, supervisor},
+     {update, pooler_starter_sup, supervisor},
+     {update, pooler_pooled_worker_sup, supervisor},
+     {delete_module, pooler_config}]
+   }
+   ],
+  [{<<".*">>, []}]}.

--- a/src/pooler_pooled_worker_sup.erl
+++ b/src/pooler_pooled_worker_sup.erl
@@ -10,7 +10,14 @@ start_link(#{start_mfa := MFA} = PoolConf) ->
     supervisor:start_link({local, SupName}, ?MODULE, MFA).
 
 init({Mod, Fun, Args}) ->
-    Worker = {Mod, {Mod, Fun, Args}, temporary, brutal_kill, worker, [Mod]},
+    Worker = #{
+        id => Mod,
+        start => {Mod, Fun, Args},
+        restart => temporary,
+        shutdown => brutal_kill,
+        type => worker,
+        modules => [Mod]
+    },
     Specs = [Worker],
-    Restart = {simple_one_for_one, 1, 1},
+    Restart = #{strategy => simple_one_for_one, intensity => 1, period => 1},
     {ok, {Restart, Specs}}.

--- a/src/pooler_starter_sup.erl
+++ b/src/pooler_starter_sup.erl
@@ -20,7 +20,14 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    Worker = {pooler_starter, {pooler_starter, start_link, []}, temporary, brutal_kill, worker, [pooler_starter]},
+    Worker = #{
+        id => pooler_starter,
+        start => {pooler_starter, start_link, []},
+        restart => temporary,
+        shutdown => brutal_kill,
+        type => worker,
+        modules => [pooler_starter]
+    },
     Specs = [Worker],
-    Restart = {simple_one_for_one, 1, 1},
+    Restart = #{strategy => simple_one_for_one, intensity => 1, period => 1},
     {ok, {Restart, Specs}}.

--- a/test/hotupgrade_test.sh
+++ b/test/hotupgrade_test.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+# Script to test release hot code upgrade
+#
+# Usage:
+#   # to generate and launch previous release, then generate a new release and upgrade files
+#   ./test/hotupgrade_test.sh setup <revision-to-upgrade-from>
+#   # to upgrade the release and perform sanity checks
+#   ./test/hotupgrade_test.sh check
+
+set -e
+set -x
+
+REBAR=`which rebar3 || echo ./rebar3`
+COMMAND=$1
+BASE_REV=$2
+
+do_setup() {
+    CUR_VERSION=`git log -1 --format='%H'`   #`git rev-parse --abbrev-ref HEAD`
+    # Building the release for the OLD version
+    if [ ! -d ebin ]; then mkdir ebin; fi
+    cp test/relx-base.config ./relx.config
+    cp src/pooler.appup.src ebin/pooler.appup
+    git checkout $BASE_REV
+    if [ ! -e src/pooled_gs.erl ]; then cp test/pooled_gs.erl src/; fi
+    $REBAR as test release
+
+    ./_build/test/rel/pooler_test/bin/pooler_test daemon
+
+    git clean -df
+
+    # Building the release and relup file with the NEW version
+    git checkout $CUR_VERSION
+    if [ ! -e src/pooled_gs.erl ]; then cp test/pooled_gs.erl src/; fi
+    $REBAR as test release --config test/relx-current.config
+    $REBAR as test relup   --config test/relx-current.config --relname pooler_test --relvsn=2.0.0 --upfrom=1.0.0
+    $REBAR as test tar     --config test/relx-current.config
+    cp _build/test/rel/pooler_test/pooler_test-2.0.0.tar.gz _build/test/rel/pooler_test/releases/
+    ./_build/test/rel/pooler_test/bin/pooler_test-1.0.0 unpack 2.0.0
+}
+
+TEST='Taken=[begin P = pooler:take_member(pool1, 1000), is_pid(P) orelse error(P), P end || _ <- lists:seq(1, 5)], [pooler:return_member(pool1, P, fail) || P <- Taken], ok.'
+
+do_check() {
+    RES1=`./_build/test/rel/pooler_test/bin/pooler_test-1.0.0 eval "${TEST}"`
+    if [ "$RES1" != "ok" ]; then
+        echo "Before upgrade checkout failed" >&2
+        echo $RES1 >&2
+        exit 1
+    fi
+    ./_build/test/rel/pooler_test/bin/pooler_test-1.0.0 upgrade 2.0.0
+    RES2=`./_build/test/rel/pooler_test/bin/pooler_test eval "${TEST}"`
+    if [ "$RES2" != "ok" ]; then
+        echo "After upgrade checkout failed" >&2
+        echo $RES2 >&2
+        exit 1
+    fi
+    ./_build/test/rel/pooler_test/bin/pooler_test stop
+}
+
+"do_$COMMAND"

--- a/test/relx-base.config
+++ b/test/relx-base.config
@@ -1,0 +1,4 @@
+{release, {pooler_test, "1.0.0"}, [sasl, pooler, runtime_tools]}.
+{sys_config, "config/demo.config"}.
+{extended_start_script, true}.
+{include_erts, false}.

--- a/test/relx-current.config
+++ b/test/relx-current.config
@@ -1,0 +1,4 @@
+{release, {pooler_test, "2.0.0"}, [sasl, {pooler, "1.6.0"}, runtime_tools]}.
+{sys_config, "config/demo.config"}.
+{extended_start_script, true}.
+{include_erts, false}.


### PR DESCRIPTION
Not sure we should actually put too much effort in supporting hot code upgrade, but I implemented it as an excercise.

The `pooler.appup.src` is able to upgrade not only the `pooler` gen_server process but also all the supervisors.